### PR TITLE
chore: Replace depreciated `ioutil.ReadFile` with `os.ReadFile` package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,14 +16,12 @@
 // By default, uncover prints file names relative to the current
 // directory when appropriate. The -l flag forces it to print absolute (long)
 // file names.
-//
 package main
 
 import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -77,7 +75,7 @@ func uncover(profile string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		src, err := ioutil.ReadFile(file)
+		src, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("can't read %q: %v", fn, err)
 		}


### PR DESCRIPTION
Thanks for the tool :) (reached here from your [GopherCon Go Testing talk](https://www.youtube.com/watch?v=X4rxi9jStLo))

Was playing with it and found an annoying warning all the time about depreciated `ioutil`. Just thought of fixing it.